### PR TITLE
Adding an os.Exit(1) when we hit an error during an execution

### DIFF
--- a/tsb.go
+++ b/tsb.go
@@ -34,6 +34,9 @@ func main() {
 		err := ex.Execute()
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err.Error())
+			/* For now just adding an error exit code. This can be done with more finese in the future
+			   with the proper code passed around but this works for now */
+			os.Exit(1)
 			break
 		}
 	}


### PR DESCRIPTION
Currently the exit code is not propagated when we hit an error and just break to exit. Adding an os.Exit(1) when we hit an error so that we can fail out properly