### PR TITLE
build-strategy: cherry or merge

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -88,14 +88,26 @@ func (e *Executor) Execute() error {
 				for _, patch_item := range cfg.Patches[name] {
 					chg := patch_item.Change
 					if chg.Node != "" {
-						err = repo.Cherry(e.Dir(), name, chg.Node)
+						if repo.BuildStrategy == BuildStrategyCherry {
+							err = repo.Cherry(e.Dir(), name, chg.Node)
+						} else if repo.BuildStrategy == BuildStrategyMerge {
+							err = repo.Merge(e.Dir(), name, chg.Node)
+						} else {
+							return fmt.Errorf("Unrecognized build strategy %s in repo yaml file", repo.BuildStrategy)
+						}
 						if err != nil {
 							return fmt.Errorf("Unable to apply %s to %s: "+chg.Node, name, err.Error())
 						}
 					} else if patch_item.Sub != nil {
 						if len(patch_item.Sub.Changesets) > 0 {
 							for _, changeset := range patch_item.Sub.Changesets {
-								err = repo.Cherry(e.Dir(), name, changeset.Node)
+								if repo.BuildStrategy == BuildStrategyCherry {
+									err = repo.Cherry(e.Dir(), name, changeset.Node)
+								} else if repo.BuildStrategy == BuildStrategyMerge {
+									err = repo.Merge(e.Dir(), name, changeset.Node)
+								} else {
+									return fmt.Errorf("Unrecognized build strategy %s in repo yaml file", repo.BuildStrategy)
+								}
 								if err != nil {
 									return fmt.Errorf("Unable to apply %s to %s: "+changeset.Node, name, err.Error())
 								}

--- a/docs/init.md
+++ b/docs/init.md
@@ -64,6 +64,7 @@ that looks like:
 ```yaml
 wgt:
   src: https://git.example.net/widget
+  build-strategy: cherry
   branch: master
   head: <long changeset id here>
   extra: []


### PR DESCRIPTION
This pull request adds the option to specify a repo's `build-strategy` as either `cherry` current behavior or `merge`. If `merge` is specified, all of the git refs specified in `patches.yaml` are merged (with `--no-ff`) instead of cherry-picked. 